### PR TITLE
Fix event reminder stage boundaries

### DIFF
--- a/backend-django/events/utils.py
+++ b/backend-django/events/utils.py
@@ -6,11 +6,11 @@ def calc_initial_stage(delta):
     Returns:
         int: The initial stage (0, 1, 2, or 3).
     """
-    if delta > timedelta(hours=3):
+    if delta >= timedelta(hours=3):
         return 0
-    elif delta > timedelta(hours=1):
+    elif delta >= timedelta(hours=1):
         return 1
-    elif delta > timedelta(minutes=20):
+    elif delta >= timedelta(minutes=20):
         return 2
     else:
         return 3


### PR DESCRIPTION
## Summary
- fix `calc_initial_stage` boundary conditions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842bd137c4883258acdf859b9aa5679