### PR TITLE
Show nicknames in likes list

### DIFF
--- a/app/src/main/java/com/narxoz/social/api/likes/likes.kt
+++ b/app/src/main/java/com/narxoz/social/api/likes/likes.kt
@@ -4,9 +4,13 @@ import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
 
+import com.google.gson.annotations.SerializedName
+
 data class LikeDto(
-    val id:        Long,
-    val author:    Int,
+    val id: Long,
+    val author: Int,
+    @SerializedName("author_nickname")
+    val authorNickname: String,
     val createdAt: String
 )
 

--- a/app/src/main/java/com/narxoz/social/ui/likes/LikesScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/likes/LikesScreen.kt
@@ -60,7 +60,7 @@ fun LikesScreen(postId: Int, onBack: () -> Unit) {
             ) {
                 items(state.likes) { like ->
                     ListItem(
-                        headlineContent = { Text("User #${'$'}{like.author}") },
+                        headlineContent = { Text(like.authorNickname) },
                         supportingContent = { Text(like.createdAt) }
                     )
                 }


### PR DESCRIPTION
## Summary
- include author_nickname in LikeDto
- display user nickname in LikesScreen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d2b719908325818b9cca1d2bf1d6