### PR TITLE
Fix token invalidation after login

### DIFF
--- a/app/src/main/java/com/narxoz/social/repository/AuthRepository.kt
+++ b/app/src/main/java/com/narxoz/social/repository/AuthRepository.kt
@@ -91,10 +91,11 @@ class AuthRepository(context: Context) {
 
     /* ---------- ctor ---------- */
     init {
-        cacheTokens(
-            localPrefs.getString(KEY_ACCESS,  null),
-            localPrefs.getString(KEY_REFRESH, null)
-        )
+        val acc = localPrefs.getString(KEY_ACCESS, null)
+        val ref = localPrefs.getString(KEY_REFRESH, null)
+        if (acc != null && ref != null) {
+            cacheTokens(acc, ref)
+        }
     }
 
     /* ---------- LOGIN ---------- */


### PR DESCRIPTION
## Summary
- keep cached access token when there is nothing saved in SharedPreferences

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684717a4925083258768c15c65e8cd61