### PR TITLE
Restrict group creation to teacher and organization roles

### DIFF
--- a/app/src/main/java/com/narxoz/social/ui/chat/ChatListScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/chat/ChatListScreen.kt
@@ -22,7 +22,7 @@ fun ChatListScreen(
 ) {
     val chats by viewModel.chats.collectAsState()
     val role = remember { AuthRepository.getUserRole() }
-    val allowCreate = role in listOf("student", "teacher", "organization")
+    val allowCreate = role in listOf("teacher", "organization")
     var showDialog by remember { mutableStateOf(false) }
     var name by remember { mutableStateOf("") }
     var members by remember { mutableStateOf("") }

--- a/app/src/main/java/com/narxoz/social/ui/chat/ChatListViewModel.kt
+++ b/app/src/main/java/com/narxoz/social/ui/chat/ChatListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.narxoz.social.network.api.ChatApi
 import com.narxoz.social.network.dto.ChatShortDto
 import com.narxoz.social.repository.ChatRepository
+import com.narxoz.social.repository.AuthRepository
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
@@ -34,6 +35,10 @@ class ChatListViewModel @Inject constructor(
     val loading: StateFlow<Boolean> = _loading.asStateFlow()
 
     fun createGroup(name: String, members: List<Int>) {
+        // Only teachers and organizations are allowed to create groups
+        val role = AuthRepository.getUserRole()
+        if (role !in listOf("teacher", "organization")) return
+
         viewModelScope.launch {
             val parts = members.map { id ->
                 MultipartBody.Part.createFormData("members", id.toString())


### PR DESCRIPTION
## Summary
- allow creating groups only for teacher and organization roles in ChatListScreen
- add the same role check to ChatListViewModel

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847513601bc83259397316d2e6fdecd