### PR TITLE
Implement in-app notifications via WebSocket

### DIFF
--- a/app/src/main/java/com/narxoz/social/network/NotificationWsManager.kt
+++ b/app/src/main/java/com/narxoz/social/network/NotificationWsManager.kt
@@ -1,0 +1,66 @@
+package com.narxoz.social.network
+
+import com.narxoz.social.BuildConfig
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import kotlin.math.pow
+
+object NotificationWsManager {
+    private var webSocket: WebSocket? = null
+    private val okHttp = OkHttpClient.Builder()
+        .retryOnConnectionFailure(true)
+        .build()
+
+    private var lastJwt: String? = null
+    private var lastListener: WebSocketListener? = null
+    private var reconnectAttempts = 0
+
+    fun connect(jwt: String, listener: WebSocketListener) {
+        lastJwt = jwt
+        lastListener = listener
+        val req = Request.Builder()
+            .url("${BuildConfig.BASE_WS_URL}/ws/notify/?token=$jwt")
+            .build()
+        webSocket = okHttp.newWebSocket(req, object : WebSocketListener() {
+            override fun onFailure(ws: WebSocket, t: Throwable, response: Response?) {
+                listener.onFailure(ws, t, response)
+                scheduleReconnect()
+            }
+
+            override fun onMessage(ws: WebSocket, text: String) {
+                reconnectAttempts = 0
+                listener.onMessage(ws, text)
+            }
+
+            override fun onClosing(ws: WebSocket, code: Int, reason: String) {
+                listener.onClosing(ws, code, reason)
+            }
+
+            override fun onClosed(ws: WebSocket, code: Int, reason: String) {
+                listener.onClosed(ws, code, reason)
+            }
+        })
+    }
+
+    private fun scheduleReconnect() {
+        val token = lastJwt ?: return
+        val lis = lastListener ?: return
+        val delayMs = (2000.0 * 2.0.pow(reconnectAttempts.toDouble())).toLong().coerceAtMost(60_000)
+        GlobalScope.launch {
+            delay(delayMs)
+            reconnectAttempts++
+            connect(token, lis)
+        }
+    }
+
+    fun close() {
+        webSocket?.close(1000, null)
+        webSocket = null
+    }
+}

--- a/app/src/main/java/com/narxoz/social/repository/NotificationsRepository.kt
+++ b/app/src/main/java/com/narxoz/social/repository/NotificationsRepository.kt
@@ -5,7 +5,7 @@ import com.narxoz.social.api.RetrofitInstance
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-class NotificationRepository {
+class NotificationsRepository {
     private val api = RetrofitInstance.notificationsApi
 
     suspend fun list(): Result<List<NotificationDto>> = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/narxoz/social/ui/MainFeedScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/MainFeedScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.pullrefresh.*
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import com.narxoz.social.ui.chat.ChatListScreen
+import com.narxoz.social.ui.NotificationsViewModel
 
 /* -------------------------------------------------------------------------- */
 /*                            PUBLIC COMPOSABLE                               */
@@ -42,6 +43,10 @@ fun MainFeedScreen(
     /* внутренний NavController – управляет вкладками bottom-bar */
     val innerNav = rememberNavController()
 
+    val notifVm: NotificationsViewModel = viewModel()
+    val notifCount by notifVm.state.map { it.unread }.collectAsState(initial = 0)
+    val rootNav = LocalNavController.current
+
     /* текущий route для подсветки иконки */
     val currentBack by innerNav.currentBackStackEntryAsState()
     val route = currentBack?.destination?.route
@@ -53,7 +58,7 @@ fun MainFeedScreen(
 
     /* -------- Scaffold с единственным BottomBar -------- */
     Scaffold(
-        topBar = { MainFeedTopBar(onToggleTheme) },
+        topBar = { MainFeedTopBar(onToggleTheme, notifCount) { rootNav.navigate("notifications") } },
         bottomBar = {
             BottomNavBar(
                 currentScreen = currentTab,
@@ -117,9 +122,6 @@ fun MainFeedScreen(
 
             /* ---------- Настройки ---------- */
             composable("settings") {
-                /* Можно безопасно вызвать здесь: мы ещё в композиции */
-                val rootNav = LocalNavController.current
-
                 SettingsScreen(
                     onLogout = {
                         rootNav.navigate("login") { popUpTo(0) }

--- a/app/src/main/java/com/narxoz/social/ui/MainFeedTopBar.kt
+++ b/app/src/main/java/com/narxoz/social/ui/MainFeedTopBar.kt
@@ -6,6 +6,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.WbSunny
 import androidx.compose.material3.*
+import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.Badge
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -18,7 +20,11 @@ import com.narxoz.social.R
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MainFeedTopBar(onToggleTheme: () -> Unit) {
+fun MainFeedTopBar(
+    onToggleTheme: () -> Unit,
+    notifications: Int,
+    onNotifications: () -> Unit
+) {
     TopAppBar(
         title = { Text("Narxoz Social") },
         colors = TopAppBarDefaults.mediumTopAppBarColors(
@@ -47,12 +53,16 @@ fun MainFeedTopBar(onToggleTheme: () -> Unit) {
                     modifier = topIconModifier
                 )
             }
-            IconButton(onClick = { /* TODO: Уведомления */ }) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_notifications),
-                    contentDescription = "Notifications",
-                    modifier = topIconModifier
-                )
+            IconButton(onClick = onNotifications) {
+                BadgedBox(badge = {
+                    if (notifications > 0) Badge { Text(notifications.toString()) }
+                }) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_notifications),
+                        contentDescription = "Notifications",
+                        modifier = topIconModifier
+                    )
+                }
             }
         }
     )

--- a/app/src/main/java/com/narxoz/social/ui/Navigation.kt
+++ b/app/src/main/java/com/narxoz/social/ui/Navigation.kt
@@ -16,6 +16,7 @@ import com.narxoz.social.ui.navigation.LocalNavController
 import com.narxoz.social.ui.likes.LikesScreen
 import com.narxoz.social.ui.orgs.OrganizationsScreen
 import com.narxoz.social.ui.PrivacyPolicyScreen
+import com.narxoz.social.ui.NotificationsScreen
 
 @Composable
 fun AppNavigation(onToggleTheme: () -> Unit) {
@@ -61,6 +62,9 @@ fun AppNavigation(onToggleTheme: () -> Unit) {
                     postId = id,
                     onBack = { navController.popBackStack() }
                 )
+            }
+            composable("notifications") {
+                NotificationsScreen { navController.popBackStack() }
             }
             composable("student") { MainFeedScreen(onToggleTheme = onToggleTheme) }
             composable("teacher") { MainFeedScreen(onToggleTheme = onToggleTheme) }

--- a/app/src/main/java/com/narxoz/social/ui/NotificationsScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/NotificationsScreen.kt
@@ -1,0 +1,91 @@
+package com.narxoz.social.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SmallTopAppBar
+import androidx.compose.material3.Text
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.rememberDismissState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.narxoz.social.api.NotificationDto
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.layout.*
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
+@Composable
+fun NotificationsScreen(onBack: () -> Unit) {
+    val vm: NotificationsViewModel = viewModel()
+    val state by vm.state.collectAsState()
+
+    val pull = rememberPullRefreshState(
+        refreshing = state.isLoading,
+        onRefresh = { vm.reload() }
+    )
+
+    Scaffold(
+        topBar = {
+            SmallTopAppBar(
+                title = { Text("Notifications") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { inner ->
+        Box(Modifier.pullRefresh(pull).padding(inner)) {
+            LazyColumn(contentPadding = PaddingValues(12.dp)) {
+                items(state.list, key = { it.id }) { notif ->
+                    val dismissState = rememberDismissState()
+                    if (dismissState.isDismissed(androidx.compose.material3.DismissDirection.EndToStart)) {
+                        vm.markRead(notif.id)
+                    }
+                    SwipeToDismissBox(
+                        state = dismissState,
+                        backgroundContent = {},
+                        content = { NotificationRow(notif) }
+                    )
+                }
+            }
+            PullRefreshIndicator(state.isLoading, pull, Modifier.align(Alignment.TopCenter))
+        }
+    }
+}
+
+@Composable
+private fun NotificationRow(n: NotificationDto) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surfaceContainerLow),
+        elevation = CardDefaults.cardElevation(1.dp)
+    ) {
+        Column(Modifier.padding(8.dp)) {
+            Text(n.text)
+            if (!n.isRead) {
+                Text("Unread", style = MaterialTheme.typography.labelSmall)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/narxoz/social/ui/NotificationsState.kt
+++ b/app/src/main/java/com/narxoz/social/ui/NotificationsState.kt
@@ -1,0 +1,10 @@
+package com.narxoz.social.ui
+
+import com.narxoz.social.api.NotificationDto
+
+data class NotificationsState(
+    val list: List<NotificationDto> = emptyList(),
+    val unread: Int = 0,
+    val isLoading: Boolean = false,
+    val error: String? = null
+)

--- a/app/src/main/java/com/narxoz/social/ui/NotificationsViewModel.kt
+++ b/app/src/main/java/com/narxoz/social/ui/NotificationsViewModel.kt
@@ -1,0 +1,69 @@
+package com.narxoz.social.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.narxoz.social.api.NotificationDto
+import com.narxoz.social.network.NotificationWsManager
+import com.narxoz.social.repository.AuthRepository
+import com.narxoz.social.repository.NotificationsRepository
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+
+class NotificationsViewModel(
+    private val repo: NotificationsRepository = NotificationsRepository()
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(NotificationsState(isLoading = true))
+    val state: StateFlow<NotificationsState> = _state.asStateFlow()
+
+    init {
+        reload()
+        val jwt = AuthRepository.getAccessToken() ?: ""
+        NotificationWsManager.connect(jwt, object : WebSocketListener() {
+            override fun onMessage(webSocket: WebSocket, text: String) {
+                val moshi = Moshi.Builder().build()
+                val adapter = moshi.adapter(NotificationDto::class.java)
+                val notif = adapter.fromJson(text) ?: return
+                viewModelScope.launch {
+                    _state.update { s ->
+                        s.copy(
+                            list = listOf(notif) + s.list,
+                            unread = s.unread + 1
+                        )
+                    }
+                }
+            }
+        })
+    }
+
+    fun reload() = viewModelScope.launch {
+        _state.update { it.copy(isLoading = true, error = null) }
+        repo.list()
+            .onSuccess { list ->
+                val unread = list.count { !it.isRead }
+                _state.update { it.copy(list = list, unread = unread, isLoading = false) }
+            }
+            .onFailure { e ->
+                _state.update { it.copy(error = e.message ?: "Network error", isLoading = false) }
+            }
+    }
+
+    fun markRead(id: Int) = viewModelScope.launch {
+        repo.markRead(id)
+        _state.update { s ->
+            val newList = s.list.map { if (it.id == id) it.copy(isRead = true) else it }
+            val unread = newList.count { !it.isRead }
+            s.copy(list = newList, unread = unread)
+        }
+    }
+
+    override fun onCleared() {
+        NotificationWsManager.close()
+    }
+}


### PR DESCRIPTION
## Summary
- add `NotificationWsManager` with reconnect logic
- create repository/viewmodel/state for notifications
- show badge and open notifications screen from top bar
- implement notifications screen with swipe-to-read
- hook new route into navigation

## Testing
- `./gradlew :app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bb0380fc832594e9211bf50d95d2