### PR TITLE
Add unread count badge for chat tab

### DIFF
--- a/app/src/main/java/com/narxoz/social/ui/BottomNavBar.kt
+++ b/app/src/main/java/com/narxoz/social/ui/BottomNavBar.kt
@@ -18,7 +18,8 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun BottomNavBar(
     currentScreen: String,
-    onScreenSelected: (String) -> Unit
+    onScreenSelected: (String) -> Unit,
+    unreadChats: Int = 0
 ) {
     val navIconModifier = Modifier.size(26.dp)   // ⬅︎ единый размер для всех
 
@@ -71,11 +72,21 @@ fun BottomNavBar(
                     || currentScreen.startsWith("chat/"),
             onClick  = { onScreenSelected("chats") },
             icon = {
-                Icon(
-                    painter = painterResource(R.drawable.ic_chat),
-                    contentDescription = "Chats",
-                    modifier = navIconModifier
-                )
+                if (unreadChats > 0) {
+                    BadgedBox(badge = { Badge { Text(unreadChats.toString()) } }) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_chat),
+                            contentDescription = "Chats",
+                            modifier = navIconModifier
+                        )
+                    }
+                } else {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_chat),
+                        contentDescription = "Chats",
+                        modifier = navIconModifier
+                    )
+                }
             },
             label  = { Text("Chats") },
             colors = itemColors()

--- a/app/src/main/java/com/narxoz/social/ui/MainFeedScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/MainFeedScreen.kt
@@ -18,6 +18,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.narxoz.social.ui.chat.ChatScreen
+import com.narxoz.social.ui.chat.ChatListViewModel
 import com.narxoz.social.ui.events.EventsScreen
 import com.narxoz.social.ui.navigation.LocalNavController
 import com.narxoz.social.ui.orgs.OrganizationsScreen
@@ -28,6 +29,7 @@ import androidx.compose.material.pullrefresh.*
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import com.narxoz.social.ui.chat.ChatListScreen
+import androidx.hilt.navigation.compose.hiltViewModel
 
 /* -------------------------------------------------------------------------- */
 /*                            PUBLIC COMPOSABLE                               */
@@ -41,6 +43,10 @@ fun MainFeedScreen(
 ) {
     /* внутренний NavController – управляет вкладками bottom-bar */
     val innerNav = rememberNavController()
+
+    /* ViewModel для списка чатов, чтобы получить число непрочитанных */
+    val chatVm: ChatListViewModel = hiltViewModel()
+    val unreadChats by chatVm.unreadCount.collectAsState()
 
     /* текущий route для подсветки иконки */
     val currentBack by innerNav.currentBackStackEntryAsState()
@@ -67,7 +73,8 @@ fun MainFeedScreen(
                             }
                         }
                     }
-                }
+                },
+                unreadChats = unreadChats
             )
         }
     ) { innerPadding ->

--- a/app/src/main/java/com/narxoz/social/ui/chat/ChatListViewModel.kt
+++ b/app/src/main/java/com/narxoz/social/ui/chat/ChatListViewModel.kt
@@ -15,6 +15,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -33,6 +36,15 @@ class ChatListViewModel @Inject constructor(
 
     /** ← публичный read-only поток */
     val loading: StateFlow<Boolean> = _loading.asStateFlow()
+
+    /** Количество непрочитанных сообщений во всех чатах */
+    val unreadCount: StateFlow<Int> = _chats
+        .map { list -> list.sumOf { it.unread } }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Lazily,
+            initialValue = 0
+        )
 
     fun createGroup(name: String, members: List<Int>) {
         // Only teachers and organizations are allowed to create groups


### PR DESCRIPTION
## Summary
- compute unread chat count in `ChatListViewModel`
- display unread message badge in `BottomNavBar`
- connect unread counter to `MainFeedScreen`

## Testing
- `./gradlew test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6849da8f78988325add00fe08815821f