### PR TITLE
Fix navigation call and add unread chat badge

### DIFF
--- a/app/src/main/java/com/narxoz/social/ui/MainFeedScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/MainFeedScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -30,6 +31,7 @@ import androidx.compose.material.pullrefresh.*
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import com.narxoz.social.ui.chat.ChatListScreen
+import com.narxoz.social.ui.chat.ChatListViewModel
 
 /* -------------------------------------------------------------------------- */
 /*                            PUBLIC COMPOSABLE                               */
@@ -47,6 +49,9 @@ fun MainFeedScreen(
     val notifVm: NotificationsViewModel = viewModel()
     val notifState by notifVm.state.collectAsState()
     val unread = notifState.notifications.count { !it.isRead }
+
+    val chatVm: ChatListViewModel = hiltViewModel()
+    val unreadChats by chatVm.unreadCount.collectAsState()
 
     /* текущий route для подсветки иконки */
     val currentBack by innerNav.currentBackStackEntryAsState()
@@ -73,7 +78,8 @@ fun MainFeedScreen(
                             }
                         }
                     }
-                }
+                },
+                unreadChats = unreadChats
             )
         }
     ) { innerPadding ->

--- a/app/src/main/java/com/narxoz/social/ui/Navigation.kt
+++ b/app/src/main/java/com/narxoz/social/ui/Navigation.kt
@@ -64,7 +64,7 @@ fun AppNavigation(onToggleTheme: () -> Unit) {
                 )
             }
             composable("notifications") {
-                NotificationsScreen { navController.popBackStack() }
+                NotificationsScreen(onBack = { navController.popBackStack() })
             }
             composable("student") { MainFeedScreen(onToggleTheme = onToggleTheme) }
             composable("teacher") { MainFeedScreen(onToggleTheme = onToggleTheme) }


### PR DESCRIPTION
## Summary
- fix NotificationsScreen call in `Navigation.kt`
- display unread chat badge in bottom bar via `MainFeedScreen`

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e673076883258b47a974bcfceb48