### PR TITLE
Fix notification text & add swipe to mark read

### DIFF
--- a/app/src/main/java/com/narxoz/social/api/NotificationsApi.kt
+++ b/app/src/main/java/com/narxoz/social/api/NotificationsApi.kt
@@ -3,13 +3,14 @@ package com.narxoz.social.api
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
+import com.google.gson.annotations.SerializedName
 
 import com.narxoz.social.api.PagedResponse
 
 data class NotificationDto(
     val id: Int,
-    val text: String?,
-    val isRead: Boolean
+    @SerializedName("text")     val text: String?,
+    @SerializedName("is_read")  val isRead: Boolean
 )
 
 interface NotificationsApi {

--- a/app/src/main/java/com/narxoz/social/ui/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/notifications/NotificationsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -57,14 +58,29 @@ fun NotificationsScreen(
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 items(state.notifications) { notif ->
-                    ListItem(
-                        headlineContent   = { Text(notif.text.orEmpty()) },
-                        trailingContent   = {
-                            if (!notif.isRead) Badge { }
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                    )
+                    val dismissState = rememberDismissState { value ->
+                        if (value != DismissValue.Default) {
+                            vm.markRead(notif.id)
+                            false
+                        } else {
+                            true
+                        }
+                    }
+
+                    SwipeToDismiss(
+                        state = dismissState,
+                        background = {},
+                        directions = setOf(DismissDirection.EndToStart, DismissDirection.StartToEnd)
+                    ) {
+                        ListItem(
+                            headlineContent = { Text(notif.text.orEmpty()) },
+                            trailingContent = {
+                                if (!notif.isRead) Badge { }
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                        )
+                    }
                     Divider()
                 }
             }


### PR DESCRIPTION
## Summary
- show notification text correctly by mapping JSON fields
- allow users to swipe notification items to mark them read

## Testing
- `./gradlew test --continue` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f124d9688325860f1d56ca9f07df