### PR TITLE
Implement friends API and notifications

### DIFF
--- a/app/src/main/java/com/narxoz/social/api/NotificationsApi.kt
+++ b/app/src/main/java/com/narxoz/social/api/NotificationsApi.kt
@@ -17,18 +17,25 @@ data class NotificationDto(
     val text: String
         get() = when (type) {
             "event_reminder" -> data?.event?.title ?: ""
+            "friend_request" -> "Friend request from ${'$'}{data?.friend?.nickname ?: ""}"
             else -> data?.toString() ?: ""
         }
 }
 
 data class NotificationData(
     val type: String?,
-    val event: EventBrief?
+    val event: EventBrief?,
+    val friend: FriendBrief?,
 )
 
 data class EventBrief(
     val id: Int,
     val title: String?
+)
+
+data class FriendBrief(
+    val id: Int,
+    val nickname: String?,
 )
 
 interface NotificationsApi {

--- a/app/src/main/java/com/narxoz/social/api/RetrofitInstance.kt
+++ b/app/src/main/java/com/narxoz/social/api/RetrofitInstance.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import com.narxoz.social.api.likes.LikesApi
 import com.narxoz.social.api.EventsApi
 import com.narxoz.social.api.NotificationsApi
+import com.narxoz.social.api.friends.FriendsApi
 import com.narxoz.social.repository.AuthRepository
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -65,5 +66,8 @@ object RetrofitInstance {
     }
     val notificationsApi: NotificationsApi by lazy {
         retrofit.create(NotificationsApi::class.java)
+    }
+    val friendsApi: FriendsApi by lazy {
+        retrofit.create(FriendsApi::class.java)
     }
 }

--- a/app/src/main/java/com/narxoz/social/api/friends/FriendsApi.kt
+++ b/app/src/main/java/com/narxoz/social/api/friends/FriendsApi.kt
@@ -1,0 +1,61 @@
+package com.narxoz.social.api.friends
+
+import com.google.gson.annotations.SerializedName
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+/**
+ * DTO для краткого представления пользователя.
+ */
+data class UserShortDto(
+    val id: Int,
+    val nickname: String?,
+    @SerializedName("avatar_path") val avatarPath: String?
+)
+
+/** Запрос на ответ на входящую заявку */
+data class FriendRespondRequest(val accepted: Boolean)
+
+/** Заявка в друзья */
+data class FriendRequestDto(
+    val id: Int,
+    val from: UserShortDto?
+)
+
+/** Статус дружбы */
+data class FriendStatusDto(val status: String)
+
+interface FriendsApi {
+    @POST("api/friends/send/{id}/")
+    suspend fun send(@Path("id") id: Int)
+
+    @DELETE("api/friends/cancel/{id}/")
+    suspend fun cancel(@Path("id") id: Int)
+
+    @DELETE("api/friends/remove/{id}/")
+    suspend fun remove(@Path("id") id: Int)
+
+    @POST("api/friends/respond/{id}/")
+    suspend fun respond(
+        @Path("id") id: Int,
+        @Body body: FriendRespondRequest
+    )
+
+    @GET("api/friends/outgoing/")
+    suspend fun outgoing(): List<FriendRequestDto>
+
+    @GET("api/friends/declined/")
+    suspend fun declined(): List<FriendRequestDto>
+
+    @GET("api/friends/status/{id}/")
+    suspend fun status(@Path("id") id: Int): FriendStatusDto
+
+    @GET("api/friends/incoming/")
+    suspend fun incoming(): List<FriendRequestDto>
+
+    @GET("api/friends/list/")
+    suspend fun list(): List<UserShortDto>
+}

--- a/app/src/main/java/com/narxoz/social/repository/FriendsRepository.kt
+++ b/app/src/main/java/com/narxoz/social/repository/FriendsRepository.kt
@@ -1,0 +1,20 @@
+package com.narxoz.social.repository
+
+import com.narxoz.social.api.RetrofitInstance
+import com.narxoz.social.api.friends.FriendRespondRequest
+import com.narxoz.social.api.friends.FriendsApi
+
+class FriendsRepository(
+    private val api: FriendsApi = RetrofitInstance.friendsApi
+) {
+    suspend fun send(id: Int) = runCatching { api.send(id) }
+    suspend fun cancel(id: Int) = runCatching { api.cancel(id) }
+    suspend fun remove(id: Int) = runCatching { api.remove(id) }
+    suspend fun respond(id: Int, accepted: Boolean) =
+        runCatching { api.respond(id, FriendRespondRequest(accepted)) }
+    suspend fun outgoing() = runCatching { api.outgoing() }
+    suspend fun declined() = runCatching { api.declined() }
+    suspend fun status(id: Int) = runCatching { api.status(id) }
+    suspend fun incoming() = runCatching { api.incoming() }
+    suspend fun list() = runCatching { api.list() }
+}


### PR DESCRIPTION
## Summary
- add client for friend endpoints and repository wrapper
- parse friend_request notifications
- expose FriendsApi in RetrofitInstance

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b509842948325bd33aa68d5df4e87