### PR TITLE
Add background indicator to swipe notifications

### DIFF
--- a/app/src/main/java/com/narxoz/social/ui/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/notifications/NotificationsScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.material.DismissDirection as MaterialDismissDirection
 import androidx.compose.material.DismissValue as MaterialDismissValue
 import androidx.compose.material.rememberDismissState as rememberMaterialDismissState
 import androidx.compose.material3.*
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -73,8 +75,32 @@ fun NotificationsScreen(
 
                     SwipeToDismiss(
                         state = dismissState,
-                        background = {},
-                        directions = setOf(MaterialDismissDirection.EndToStart, MaterialDismissDirection.StartToEnd)
+                        directions = setOf(
+                            MaterialDismissDirection.EndToStart,
+                            MaterialDismissDirection.StartToEnd
+                        ),
+                        background = {
+                            val color by animateColorAsState(
+                                if (dismissState.targetValue == MaterialDismissValue.Default)
+                                    MaterialTheme.colorScheme.surfaceContainerLow
+                                else
+                                    MaterialTheme.colorScheme.primaryContainer
+                            )
+                            val alignment = when (dismissState.dismissDirection) {
+                                MaterialDismissDirection.StartToEnd -> Alignment.CenterStart
+                                MaterialDismissDirection.EndToStart -> Alignment.CenterEnd
+                                null -> Alignment.CenterStart
+                            }
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .background(color)
+                                    .padding(horizontal = 24.dp),
+                                contentAlignment = alignment
+                            ) {
+                                Icon(Icons.Default.Done, contentDescription = null)
+                            }
+                        }
                     ) {
                         ListItem(
                             headlineContent = { Text(notif.text) },


### PR DESCRIPTION
## Summary
- show an animated background when swiping notifications

## Testing
- `./gradlew assembleDebug --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b71d755488325859ba7d8a4a38db8