### PR TITLE
Fix friend request notifications

### DIFF
--- a/app/src/main/java/com/narxoz/social/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/narxoz/social/ui/notifications/NotificationsViewModel.kt
@@ -29,7 +29,7 @@ class NotificationsViewModel(
         notifsRes
             .onSuccess { list ->
                 val incomingMap = incomingRes.getOrNull()
-                    ?.associateBy { it.fromUser?.id }
+                    ?.associateBy { it.id }
                     ?: emptyMap()
 
                 val patched = list.map { n ->


### PR DESCRIPTION
## Summary
- map incoming friend requests by request ID when patching notifications

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b883469948325addca991e7dffb1a