### PR TITLE
Fix friend request actions

### DIFF
--- a/app/src/main/java/com/narxoz/social/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/narxoz/social/ui/notifications/NotificationsViewModel.kt
@@ -29,20 +29,23 @@ class NotificationsViewModel(
         notifsRes
             .onSuccess { list ->
                 val incomingMap = incomingRes.getOrNull()
-                    ?.associateBy { it.id }
+                    ?.associateBy { it.fromUser?.id }
                     ?: emptyMap()
 
                 val patched = list.map { n ->
                     if (n.type == "friend_request") {
-                        val fid = n.data?.friend?.id
-                        val name = fid?.let {
-                            incomingMap[fid]?.fromUser?.fullName
-                                ?: incomingMap[fid]?.fromUser?.nickname
-                        }
-                        if (!name.isNullOrBlank()) {
+                        val uid = n.data?.friend?.id
+                        val req = uid?.let { incomingMap[uid] }
+                        val name = req?.fromUser?.fullName ?: req?.fromUser?.nickname
+                        val reqId = req?.id
+
+                        if (reqId != null || !name.isNullOrBlank()) {
                             n.copy(
                                 data = n.data?.copy(
-                                    friend = n.data.friend?.copy(nickname = name)
+                                    friend = n.data.friend?.copy(
+                                        id = reqId ?: uid,
+                                        nickname = name ?: n.data.friend?.nickname
+                                    )
                                 )
                             )
                         } else n


### PR DESCRIPTION
## Summary
- fix incoming request lookup to store the request id so notifications now send the correct id to `/api/friends/respond/`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8ef761808325ad8268ac1a77d7e4