### PR TITLE
Add user profile screen

### DIFF
--- a/app/src/main/java/com/narxoz/social/api/RetrofitInstance.kt
+++ b/app/src/main/java/com/narxoz/social/api/RetrofitInstance.kt
@@ -5,6 +5,7 @@ import com.narxoz.social.api.likes.LikesApi
 import com.narxoz.social.api.EventsApi
 import com.narxoz.social.api.NotificationsApi
 import com.narxoz.social.api.friends.FriendsApi
+import com.narxoz.social.api.profile.ProfileApi
 import com.narxoz.social.repository.AuthRepository
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -69,5 +70,8 @@ object RetrofitInstance {
     }
     val friendsApi: FriendsApi by lazy {
         retrofit.create(FriendsApi::class.java)
+    }
+    val profileApi: ProfileApi by lazy {
+        retrofit.create(ProfileApi::class.java)
     }
 }

--- a/app/src/main/java/com/narxoz/social/api/profile/ProfileApi.kt
+++ b/app/src/main/java/com/narxoz/social/api/profile/ProfileApi.kt
@@ -1,0 +1,19 @@
+package com.narxoz.social.api.profile
+
+import com.google.gson.annotations.SerializedName
+import retrofit2.http.GET
+
+/** DTO профиля пользователя. */
+data class UserProfileDto(
+    val id: Int,
+    @SerializedName("full_name") val fullName: String?,
+    val nickname: String?,
+    @SerializedName("avatar_path") val avatarPath: String?,
+    val email: String?
+)
+
+interface ProfileApi {
+    /** Возвращает профиль текущего пользователя. */
+    @GET("api/users/profile/")
+    suspend fun getProfile(): UserProfileDto
+}

--- a/app/src/main/java/com/narxoz/social/repository/ProfileRepository.kt
+++ b/app/src/main/java/com/narxoz/social/repository/ProfileRepository.kt
@@ -1,0 +1,15 @@
+package com.narxoz.social.repository
+
+import com.narxoz.social.api.RetrofitInstance
+import com.narxoz.social.api.profile.ProfileApi
+import com.narxoz.social.api.profile.UserProfileDto
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class ProfileRepository(
+    private val api: ProfileApi = RetrofitInstance.profileApi
+) {
+    suspend fun load(): Result<UserProfileDto> = withContext(Dispatchers.IO) {
+        runCatching { api.getProfile() }
+    }
+}

--- a/app/src/main/java/com/narxoz/social/ui/MainFeedScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/MainFeedScreen.kt
@@ -63,8 +63,17 @@ fun MainFeedScreen(
     }
 
     /* -------- Scaffold с единственным BottomBar -------- */
+    val rootNav = LocalNavController.current
+
     Scaffold(
-        topBar = { MainFeedTopBar(onToggleTheme, unread) { innerNav.navigate("notifications") } },
+        topBar = {
+            MainFeedTopBar(
+                onToggleTheme = onToggleTheme,
+                notifications = unread,
+                onNotifications = { innerNav.navigate("notifications") },
+                onProfile = { rootNav.navigate("profile") }
+            )
+        },
         bottomBar = {
             BottomNavBar(
                 currentScreen = currentTab,

--- a/app/src/main/java/com/narxoz/social/ui/MainFeedTopBar.kt
+++ b/app/src/main/java/com/narxoz/social/ui/MainFeedTopBar.kt
@@ -23,7 +23,8 @@ import com.narxoz.social.R
 fun MainFeedTopBar(
     onToggleTheme: () -> Unit,
     notifications: Int,
-    onNotifications: () -> Unit
+    onNotifications: () -> Unit,
+    onProfile: () -> Unit
 ) {
     TopAppBar(
         title = { Text("Narxoz Social") },
@@ -39,7 +40,7 @@ fun MainFeedTopBar(
                 Icon(icon, contentDescription = "Toggle theme")
             }
             val topIconModifier = Modifier.size(28.dp)
-            IconButton(onClick = { /* TODO: Переход в профиль */ }) {
+            IconButton(onClick = onProfile) {
                 Icon(
                     painter = painterResource(R.drawable.ic_profile),
                     contentDescription = "Profile",

--- a/app/src/main/java/com/narxoz/social/ui/Navigation.kt
+++ b/app/src/main/java/com/narxoz/social/ui/Navigation.kt
@@ -19,6 +19,7 @@ import com.narxoz.social.ui.PrivacyPolicyScreen
 import com.narxoz.social.ui.notifications.NotificationsScreen
 import com.narxoz.social.ui.friends.AddFriendScreen
 import com.narxoz.social.ui.friends.FriendsListScreen
+import com.narxoz.social.ui.profile.ProfileScreen
 
 @Composable
 fun AppNavigation(onToggleTheme: () -> Unit) {
@@ -76,6 +77,9 @@ fun AppNavigation(onToggleTheme: () -> Unit) {
             }
             composable("friends") {
                 FriendsListScreen(onBack = { navController.popBackStack() })
+            }
+            composable("profile") {
+                ProfileScreen(onBack = { navController.popBackStack() })
             }
         }
     }

--- a/app/src/main/java/com/narxoz/social/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/profile/ProfileScreen.kt
@@ -1,0 +1,68 @@
+package com.narxoz.social.ui.profile
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen(onBack: () -> Unit = {}) {
+    val vm: ProfileViewModel = viewModel()
+    val state by vm.state.collectAsState()
+
+    Scaffold(
+        topBar = {
+            SmallTopAppBar(
+                title = { Text("Профиль") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { inner ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(inner)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            when {
+                state.isLoading -> CircularProgressIndicator()
+                state.error != null -> Text(state.error!!, color = MaterialTheme.colorScheme.error)
+                state.profile != null -> ProfileContent(state)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProfileContent(state: ProfileState) {
+    val profile = state.profile ?: return
+    profile.avatarPath?.let { url ->
+        AsyncImage(
+            model = url.replace("127.0.0.1", "10.0.2.2"),
+            contentDescription = null,
+            modifier = Modifier.size(120.dp)
+        )
+    }
+    Text(
+        profile.fullName ?: profile.nickname ?: "ID ${profile.id}",
+        style = MaterialTheme.typography.headlineSmall
+    )
+    if (!profile.email.isNullOrBlank()) {
+        Text(profile.email!!, style = MaterialTheme.typography.bodyMedium)
+    }
+}

--- a/app/src/main/java/com/narxoz/social/ui/profile/ProfileState.kt
+++ b/app/src/main/java/com/narxoz/social/ui/profile/ProfileState.kt
@@ -1,0 +1,10 @@
+package com.narxoz.social.ui.profile
+
+import com.narxoz.social.api.profile.UserProfileDto
+
+/** Состояние экрана профиля. */
+data class ProfileState(
+    val profile: UserProfileDto? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null
+)

--- a/app/src/main/java/com/narxoz/social/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/narxoz/social/ui/profile/ProfileViewModel.kt
@@ -1,0 +1,29 @@
+package com.narxoz.social.ui.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.narxoz.social.repository.ProfileRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class ProfileViewModel(
+    private val repo: ProfileRepository = ProfileRepository()
+) : ViewModel() {
+    private val _state = MutableStateFlow(ProfileState(isLoading = true))
+    val state: StateFlow<ProfileState> = _state.asStateFlow()
+
+    init { load() }
+
+    fun load() = viewModelScope.launch {
+        _state.value = ProfileState(isLoading = true)
+        repo.load()
+            .onSuccess { prof ->
+                _state.value = ProfileState(profile = prof, isLoading = false)
+            }
+            .onFailure { e ->
+                _state.value = ProfileState(isLoading = false, error = e.message ?: "Ошибка")
+            }
+    }
+}


### PR DESCRIPTION
## Summary
- fetch profile via new `ProfileApi`
- expose new `ProfileRepository`
- show profile in new screen with ViewModel
- hook profile screen into navigation and top bar
- register `profileApi` in `RetrofitInstance`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb72e81048325abfc67798483f955