### PR TITLE
Add another user profile screen

### DIFF
--- a/app/src/main/java/com/narxoz/social/api/profile/AnotherUserProfileDto.kt
+++ b/app/src/main/java/com/narxoz/social/api/profile/AnotherUserProfileDto.kt
@@ -1,0 +1,15 @@
+package com.narxoz.social.api.profile
+
+import com.google.gson.annotations.SerializedName
+import com.narxoz.social.api.friends.UserShortDto
+
+/** DTO профиля другого пользователя. */
+data class AnotherUserProfileDto(
+    val id: Int,
+    @SerializedName("full_name") val fullName: String?,
+    val nickname: String?,
+    @SerializedName("avatar_path") val avatarPath: String?,
+    val friends: List<UserShortDto>?,
+    @SerializedName("last_seen") val lastSeen: String?,
+    @SerializedName("is_online") val isOnline: Boolean?
+)

--- a/app/src/main/java/com/narxoz/social/api/profile/ProfileApi.kt
+++ b/app/src/main/java/com/narxoz/social/api/profile/ProfileApi.kt
@@ -7,6 +7,7 @@ import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.PATCH
 import retrofit2.http.Part
+import retrofit2.http.Path
 
 /** DTO профиля пользователя. */
 data class UserProfileDto(
@@ -21,6 +22,10 @@ interface ProfileApi {
     /** Возвращает профиль текущего пользователя. */
     @GET("api/users/profile/")
     suspend fun getProfile(): UserProfileDto
+
+    /** Возвращает профиль другого пользователя по ID. */
+    @GET("api/users/profile/{id}/")
+    suspend fun getProfileById(@Path("id") id: Int): AnotherUserProfileDto
 
     /** Обновить профиль пользователя (nickname и аватар). */
     @Multipart

--- a/app/src/main/java/com/narxoz/social/repository/ProfileRepository.kt
+++ b/app/src/main/java/com/narxoz/social/repository/ProfileRepository.kt
@@ -3,6 +3,7 @@ package com.narxoz.social.repository
 import com.narxoz.social.api.RetrofitInstance
 import com.narxoz.social.api.profile.ProfileApi
 import com.narxoz.social.api.profile.UserProfileDto
+import com.narxoz.social.api.profile.AnotherUserProfileDto
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
@@ -16,6 +17,10 @@ class ProfileRepository(
 ) {
     suspend fun load(): Result<UserProfileDto> = withContext(Dispatchers.IO) {
         runCatching { api.getProfile() }
+    }
+
+    suspend fun loadById(id: Int): Result<AnotherUserProfileDto> = withContext(Dispatchers.IO) {
+        runCatching { api.getProfileById(id) }
     }
 
     suspend fun update(nickname: String?, avatar: File?): Result<UserProfileDto> =

--- a/app/src/main/java/com/narxoz/social/ui/Navigation.kt
+++ b/app/src/main/java/com/narxoz/social/ui/Navigation.kt
@@ -21,6 +21,7 @@ import com.narxoz.social.ui.friends.AddFriendScreen
 import com.narxoz.social.ui.friends.FriendsListScreen
 import com.narxoz.social.ui.profile.ProfileScreen
 import com.narxoz.social.ui.profile.EditProfileScreen
+import com.narxoz.social.ui.profile.AnotherProfileScreen
 
 @Composable
 fun AppNavigation(onToggleTheme: () -> Unit) {
@@ -78,6 +79,16 @@ fun AppNavigation(onToggleTheme: () -> Unit) {
             }
             composable("friends") {
                 FriendsListScreen(onBack = { navController.popBackStack() })
+            }
+            composable(
+                route = "user/{id}",
+                arguments = listOf(navArgument("id") { type = NavType.IntType })
+            ) { backStack ->
+                val id = backStack.arguments!!.getInt("id")
+                AnotherProfileScreen(
+                    userId = id,
+                    onBack = { navController.popBackStack() }
+                )
             }
             composable("profile") {
                 ProfileScreen(

--- a/app/src/main/java/com/narxoz/social/ui/friends/FriendsListScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/friends/FriendsListScreen.kt
@@ -3,6 +3,7 @@ package com.narxoz.social.ui.friends
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
@@ -13,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.narxoz.social.ui.navigation.LocalNavController
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -21,6 +23,7 @@ fun FriendsListScreen(
     vm: FriendsListViewModel = viewModel(),
 ) {
     val state by vm.state.collectAsState()
+    val navController = LocalNavController.current
 
     Scaffold(
         topBar = {
@@ -60,7 +63,8 @@ fun FriendsListScreen(
                     ListItem(
                         headlineContent = {
                             Text(friend.nickname ?: friend.fullName ?: "ID ${friend.id}")
-                        }
+                        },
+                        modifier = Modifier.clickable { navController.navigate("user/${friend.id}") }
                     )
                     Divider()
                 }

--- a/app/src/main/java/com/narxoz/social/ui/profile/AnotherProfileScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/profile/AnotherProfileScreen.kt
@@ -1,0 +1,65 @@
+package com.narxoz.social.ui.profile
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnotherProfileScreen(userId: Int, onBack: () -> Unit = {}) {
+    val vm: AnotherProfileViewModel = viewModel(factory = AnotherProfileVmFactory(userId))
+    val state by vm.state.collectAsState()
+
+    Scaffold(
+        topBar = {
+            SmallTopAppBar(
+                title = { Text("Профиль") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { inner ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(inner)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            when {
+                state.isLoading -> CircularProgressIndicator()
+                state.error != null -> Text(state.error!!, color = MaterialTheme.colorScheme.error)
+                state.profile != null -> AnotherProfileContent(state)
+            }
+        }
+    }
+}
+
+@Composable
+private fun AnotherProfileContent(state: AnotherProfileState) {
+    val profile = state.profile ?: return
+    profile.avatarPath?.let { url ->
+        AsyncImage(
+            model = url.replace("127.0.0.1", "10.0.2.2"),
+            contentDescription = null,
+            modifier = Modifier.size(120.dp)
+        )
+    }
+    Text(
+        profile.fullName ?: profile.nickname ?: "ID ${'$'}{profile.id}",
+        style = MaterialTheme.typography.headlineSmall
+    )
+}

--- a/app/src/main/java/com/narxoz/social/ui/profile/AnotherProfileState.kt
+++ b/app/src/main/java/com/narxoz/social/ui/profile/AnotherProfileState.kt
@@ -1,0 +1,10 @@
+package com.narxoz.social.ui.profile
+
+import com.narxoz.social.api.profile.AnotherUserProfileDto
+
+/** Состояние экрана чужого профиля. */
+data class AnotherProfileState(
+    val profile: AnotherUserProfileDto? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null
+)

--- a/app/src/main/java/com/narxoz/social/ui/profile/AnotherProfileViewModel.kt
+++ b/app/src/main/java/com/narxoz/social/ui/profile/AnotherProfileViewModel.kt
@@ -1,0 +1,38 @@
+package com.narxoz.social.ui.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.narxoz.social.repository.ProfileRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class AnotherProfileViewModel(
+    private val userId: Int,
+    private val repo: ProfileRepository = ProfileRepository()
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(AnotherProfileState(isLoading = true))
+    val state: StateFlow<AnotherProfileState> = _state.asStateFlow()
+
+    init { load() }
+
+    fun load() = viewModelScope.launch {
+        _state.value = AnotherProfileState(isLoading = true)
+        repo.loadById(userId)
+            .onSuccess { prof ->
+                _state.value = AnotherProfileState(profile = prof, isLoading = false)
+            }
+            .onFailure { e ->
+                _state.value = AnotherProfileState(isLoading = false, error = e.message ?: "Ошибка")
+            }
+    }
+}
+
+class AnotherProfileVmFactory(private val userId: Int) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T =
+        AnotherProfileViewModel(userId) as T
+}


### PR DESCRIPTION
## Summary
- support retrieving another user's profile in ProfileApi and repository
- implement AnotherProfileScreen, ViewModel, State, DTO
- navigate to user screen from friends list
- add navigation route for viewing user profile by ID

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc0851f8c8325a27fe3ed548681d5