### PR TITLE
Implement friend management and status features

### DIFF
--- a/app/src/main/java/com/narxoz/social/notification/FCMService.kt
+++ b/app/src/main/java/com/narxoz/social/notification/FCMService.kt
@@ -19,7 +19,7 @@ class FCMService : FirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
-        Log.d("FCMService", "Message: ${'$'}{message.data}")
+        Log.d("FCMService", "Message: ${message.data}")
         showNotification(message)
     }
 

--- a/app/src/main/java/com/narxoz/social/ui/friends/FriendsListScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/friends/FriendsListScreen.kt
@@ -81,58 +81,72 @@ fun FriendsListScreen(
                 ) { Text(state.error ?: "", color = MaterialTheme.colorScheme.error) }
 
                 else -> {
-                    val list = when (state.tab) {
-                        FriendsTab.FRIENDS -> state.friends.filter {
-                            it.nickname?.contains(state.filter, true) == true ||
-                                    it.fullName?.contains(state.filter, true) == true
+                    when (state.tab) {
+                        FriendsTab.FRIENDS -> {
+                            val friends = state.friends.filter {
+                                it.nickname?.contains(state.filter, true) == true ||
+                                        it.fullName?.contains(state.filter, true) == true
+                            }
+                            LazyColumn(
+                                modifier = Modifier.fillMaxSize(),
+                                contentPadding = PaddingValues(12.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                items(friends) { friend ->
+                                    ListItem(
+                                        headlineContent = {
+                                            Text(friend.nickname ?: friend.fullName ?: "ID ${'$'}{friend.id}")
+                                        },
+                                        trailingContent = {
+                                            IconButton(onClick = { vm.removeFriend(friend.id) }) {
+                                                Icon(Icons.Default.Delete, null)
+                                            }
+                                        },
+                                        modifier = Modifier.clickable {
+                                            navController.navigate("user/${'$'}{friend.id}")
+                                        }
+                                    )
+                                    Divider()
+                                }
+                            }
                         }
-                        FriendsTab.INCOMING -> state.incoming
-                        FriendsTab.OUTGOING -> state.outgoing
-                    }
-                    LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        when (state.tab) {
-                            FriendsTab.FRIENDS -> items(list) { friend ->
-                                ListItem(
-                                    headlineContent = {
-                                        Text(friend.nickname ?: friend.fullName ?: "ID ${'$'}{friend.id}")
-                                    },
-                                    trailingContent = {
-                                        IconButton(onClick = { vm.removeFriend(friend.id) }) {
-                                            Icon(Icons.Default.Delete, null)
+                        FriendsTab.INCOMING -> {
+                            LazyColumn(
+                                modifier = Modifier.fillMaxSize(),
+                                contentPadding = PaddingValues(12.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                items(state.incoming) { req ->
+                                    val user = req.fromUser
+                                    ListItem(
+                                        headlineContent = {
+                                            Text(user?.nickname ?: user?.fullName ?: "ID ${'$'}{user?.id}")
                                         }
-                                    },
-                                    modifier = Modifier.clickable {
-                                        navController.navigate("user/${'$'}{friend.id}")
-                                    }
-                                )
-                                Divider()
+                                    )
+                                    Divider()
+                                }
                             }
-                            FriendsTab.INCOMING -> items(list) { req ->
-                                val user = req.fromUser
-                                ListItem(
-                                    headlineContent = {
-                                        Text(user?.nickname ?: user?.fullName ?: "ID ${'$'}{user?.id}")
-                                    }
-                                )
-                                Divider()
-                            }
-                            FriendsTab.OUTGOING -> items(list) { req ->
-                                val user = req.toUser
-                                ListItem(
-                                    headlineContent = {
-                                        Text(user?.nickname ?: user?.fullName ?: "ID ${'$'}{user?.id}")
-                                    },
-                                    trailingContent = {
-                                        IconButton(onClick = { vm.cancelRequest(req.id) }) {
-                                            Icon(Icons.Default.Cancel, null)
+                        }
+                        FriendsTab.OUTGOING -> {
+                            LazyColumn(
+                                modifier = Modifier.fillMaxSize(),
+                                contentPadding = PaddingValues(12.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                items(state.outgoing) { req ->
+                                    val user = req.toUser
+                                    ListItem(
+                                        headlineContent = {
+                                            Text(user?.nickname ?: user?.fullName ?: "ID ${'$'}{user?.id}")
+                                        },
+                                        trailingContent = {
+                                            IconButton(onClick = { vm.cancelRequest(req.id) }) {
+                                                Icon(Icons.Default.Cancel, null)
+                                            }
                                         }
-                                    }
-                                )
-                                Divider()
+                                    )
+                                    Divider()
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/narxoz/social/ui/friends/FriendsListScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/friends/FriendsListScreen.kt
@@ -95,7 +95,7 @@ fun FriendsListScreen(
                                 items(friends) { friend ->
                                     ListItem(
                                         headlineContent = {
-                                            Text(friend.nickname ?: friend.fullName ?: "ID ${'$'}{friend.id}")
+                                            Text(friend.nickname ?: friend.fullName ?: "ID ${friend.id}")
                                         },
                                         trailingContent = {
                                             IconButton(onClick = { vm.removeFriend(friend.id) }) {
@@ -103,7 +103,7 @@ fun FriendsListScreen(
                                             }
                                         },
                                         modifier = Modifier.clickable {
-                                            navController.navigate("user/${'$'}{friend.id}")
+                                            navController.navigate("user/${friend.id}")
                                         }
                                     )
                                     Divider()
@@ -120,7 +120,7 @@ fun FriendsListScreen(
                                     val user = req.fromUser
                                     ListItem(
                                         headlineContent = {
-                                            Text(user?.nickname ?: user?.fullName ?: "ID ${'$'}{user?.id}")
+                                    Text(user?.nickname ?: user?.fullName ?: "ID ${user?.id}")
                                         }
                                     )
                                     Divider()
@@ -137,7 +137,7 @@ fun FriendsListScreen(
                                     val user = req.toUser
                                     ListItem(
                                         headlineContent = {
-                                            Text(user?.nickname ?: user?.fullName ?: "ID ${'$'}{user?.id}")
+                                            Text(user?.nickname ?: user?.fullName ?: "ID ${user?.id}")
                                         },
                                         trailingContent = {
                                             IconButton(onClick = { vm.cancelRequest(req.id) }) {

--- a/app/src/main/java/com/narxoz/social/ui/friends/FriendsListScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/friends/FriendsListScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -37,36 +39,103 @@ fun FriendsListScreen(
             )
         }
     ) { inner ->
-        when {
-            state.isLoading -> Box(
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(inner)
+        ) {
+            ScrollableTabRow(selectedTabIndex = state.tab.ordinal) {
+                Tab(
+                    text = { Text("Друзья") },
+                    selected = state.tab == FriendsTab.FRIENDS,
+                    onClick = { vm.changeTab(FriendsTab.FRIENDS) }
+                )
+                Tab(
+                    text = { Text("Входящие") },
+                    selected = state.tab == FriendsTab.INCOMING,
+                    onClick = { vm.changeTab(FriendsTab.INCOMING) }
+                )
+                Tab(
+                    text = { Text("Исходящие") },
+                    selected = state.tab == FriendsTab.OUTGOING,
+                    onClick = { vm.changeTab(FriendsTab.OUTGOING) }
+                )
+            }
+            OutlinedTextField(
+                value = state.filter,
+                onValueChange = vm::updateFilter,
+                label = { Text("Фильтр") },
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(inner),
-                contentAlignment = Alignment.Center
-            ) { CircularProgressIndicator() }
+                    .fillMaxWidth()
+                    .padding(8.dp)
+            )
+            when {
+                state.isLoading -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) { CircularProgressIndicator() }
 
-            state.error != null -> Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(inner),
-                contentAlignment = Alignment.Center
-            ) { Text(state.error ?: "", color = MaterialTheme.colorScheme.error) }
+                state.error != null -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) { Text(state.error ?: "", color = MaterialTheme.colorScheme.error) }
 
-            else -> LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(inner),
-                contentPadding = PaddingValues(12.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                items(state.friends) { friend ->
-                    ListItem(
-                        headlineContent = {
-                            Text(friend.nickname ?: friend.fullName ?: "ID ${friend.id}")
-                        },
-                        modifier = Modifier.clickable { navController.navigate("user/${friend.id}") }
-                    )
-                    Divider()
+                else -> {
+                    val list = when (state.tab) {
+                        FriendsTab.FRIENDS -> state.friends.filter {
+                            it.nickname?.contains(state.filter, true) == true ||
+                                    it.fullName?.contains(state.filter, true) == true
+                        }
+                        FriendsTab.INCOMING -> state.incoming
+                        FriendsTab.OUTGOING -> state.outgoing
+                    }
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        when (state.tab) {
+                            FriendsTab.FRIENDS -> items(list) { friend ->
+                                ListItem(
+                                    headlineContent = {
+                                        Text(friend.nickname ?: friend.fullName ?: "ID ${'$'}{friend.id}")
+                                    },
+                                    trailingContent = {
+                                        IconButton(onClick = { vm.removeFriend(friend.id) }) {
+                                            Icon(Icons.Default.Delete, null)
+                                        }
+                                    },
+                                    modifier = Modifier.clickable {
+                                        navController.navigate("user/${'$'}{friend.id}")
+                                    }
+                                )
+                                Divider()
+                            }
+                            FriendsTab.INCOMING -> items(list) { req ->
+                                val user = req.fromUser
+                                ListItem(
+                                    headlineContent = {
+                                        Text(user?.nickname ?: user?.fullName ?: "ID ${'$'}{user?.id}")
+                                    }
+                                )
+                                Divider()
+                            }
+                            FriendsTab.OUTGOING -> items(list) { req ->
+                                val user = req.toUser
+                                ListItem(
+                                    headlineContent = {
+                                        Text(user?.nickname ?: user?.fullName ?: "ID ${'$'}{user?.id}")
+                                    },
+                                    trailingContent = {
+                                        IconButton(onClick = { vm.cancelRequest(req.id) }) {
+                                            Icon(Icons.Default.Cancel, null)
+                                        }
+                                    }
+                                )
+                                Divider()
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/narxoz/social/ui/friends/FriendsListState.kt
+++ b/app/src/main/java/com/narxoz/social/ui/friends/FriendsListState.kt
@@ -1,10 +1,18 @@
 package com.narxoz.social.ui.friends
 
+import com.narxoz.social.api.friends.FriendRequestDto
 import com.narxoz.social.api.friends.UserShortDto
 
-/** Состояние экрана со списком друзей */
+/** Tab categories on friends screen */
+enum class FriendsTab { FRIENDS, INCOMING, OUTGOING }
+
+/** Состояние экрана со списком друзей и заявок */
 data class FriendsListState(
     val friends: List<UserShortDto> = emptyList(),
+    val incoming: List<FriendRequestDto> = emptyList(),
+    val outgoing: List<FriendRequestDto> = emptyList(),
+    val tab: FriendsTab = FriendsTab.FRIENDS,
+    val filter: String = "",
     val isLoading: Boolean = false,
     val error: String? = null,
 )

--- a/app/src/main/java/com/narxoz/social/ui/profile/AnotherProfileScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/profile/AnotherProfileScreen.kt
@@ -62,4 +62,7 @@ private fun AnotherProfileContent(state: AnotherProfileState) {
         profile.fullName ?: profile.nickname ?: "ID ${'$'}{profile.id}",
         style = MaterialTheme.typography.headlineSmall
     )
+    state.friendStatus?.let { status ->
+        Text("Статус: $status")
+    }
 }

--- a/app/src/main/java/com/narxoz/social/ui/profile/AnotherProfileScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/profile/AnotherProfileScreen.kt
@@ -59,7 +59,7 @@ private fun AnotherProfileContent(state: AnotherProfileState) {
         )
     }
     Text(
-        profile.fullName ?: profile.nickname ?: "ID ${'$'}{profile.id}",
+        profile.fullName ?: profile.nickname ?: "ID ${profile.id}",
         style = MaterialTheme.typography.headlineSmall
     )
     state.friendStatus?.let { status ->

--- a/app/src/main/java/com/narxoz/social/ui/profile/AnotherProfileState.kt
+++ b/app/src/main/java/com/narxoz/social/ui/profile/AnotherProfileState.kt
@@ -5,6 +5,7 @@ import com.narxoz.social.api.profile.AnotherUserProfileDto
 /** Состояние экрана чужого профиля. */
 data class AnotherProfileState(
     val profile: AnotherUserProfileDto? = null,
+    val friendStatus: String? = null,
     val isLoading: Boolean = false,
-    val error: String? = null
+    val error: String? = null,
 )


### PR DESCRIPTION
## Summary
- expand FriendsList state to keep incoming/outgoing requests
- update FriendsList view model with cancel/remove logic
- redesign FriendsList screen with tabs and filtering
- expose friendship status in another user's profile

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cdd42996483258eca5dd5f211ceed