### PR TITLE
Add organization joining and editing features

### DIFF
--- a/app/src/main/java/com/narxoz/social/ui/Navigation.kt
+++ b/app/src/main/java/com/narxoz/social/ui/Navigation.kt
@@ -22,6 +22,7 @@ import com.narxoz.social.ui.friends.FriendsListScreen
 import com.narxoz.social.ui.profile.ProfileScreen
 import com.narxoz.social.ui.profile.EditProfileScreen
 import com.narxoz.social.ui.profile.AnotherProfileScreen
+import com.narxoz.social.ui.orgs.OrganizationDetailScreen
 import com.narxoz.social.ui.post.CreatePostScreen
 import com.narxoz.social.ui.post.PostDetailScreen
 import com.narxoz.social.ui.post.EditPostScreen
@@ -102,6 +103,17 @@ fun AppNavigation(onToggleTheme: () -> Unit) {
             composable("student") { MainFeedScreen(onToggleTheme = onToggleTheme) }
             composable("teacher") { MainFeedScreen(onToggleTheme = onToggleTheme) }
             composable("organizations") { OrganizationsScreen() }
+            composable(
+                route = "organization/{id}",
+                arguments = listOf(navArgument("id") { type = NavType.IntType })
+            ) { backStack ->
+                val id = backStack.arguments!!.getInt("id")
+                OrganizationDetailScreen(
+                    orgId = id,
+                    onBack = { navController.popBackStack() },
+                    onEdit = { navController.navigate("editProfile") }
+                )
+            }
             composable("addFriend") {
                 AddFriendScreen(onBack = { navController.popBackStack() })
             }

--- a/app/src/main/java/com/narxoz/social/ui/orgs/OrganizationDetailScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/orgs/OrganizationDetailScreen.kt
@@ -1,0 +1,81 @@
+package com.narxoz.social.ui.orgs
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+import com.narxoz.social.repository.AuthRepository
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OrganizationDetailScreen(
+    orgId: Int,
+    onBack: () -> Unit = {},
+    onEdit: () -> Unit = {},
+) {
+    val vm: OrganizationDetailViewModel = viewModel(factory = OrganizationDetailVmFactory(orgId))
+    val state by vm.state.collectAsState()
+    val myId = AuthRepository.getUserId()
+    val role = AuthRepository.getUserRole()
+    val canEdit = myId == orgId && role == "organization"
+
+    Scaffold(
+        topBar = {
+            SmallTopAppBar(
+                title = { Text("Организация") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = null)
+                    }
+                },
+                actions = {
+                    if (canEdit) {
+                        IconButton(onClick = onEdit) {
+                            Icon(Icons.Default.Edit, contentDescription = null)
+                        }
+                    }
+                }
+            )
+        }
+    ) { inner ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(inner)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            when {
+                state.isLoading -> CircularProgressIndicator()
+                state.error != null -> Text(state.error!!, color = MaterialTheme.colorScheme.error)
+                state.profile != null -> {
+                    val prof = state.profile
+                    prof?.avatarPath?.let { url ->
+                        AsyncImage(
+                            model = url.replace("127.0.0.1", "10.0.2.2"),
+                            contentDescription = null,
+                            modifier = Modifier.size(120.dp)
+                        )
+                    }
+                    Text(prof?.fullName ?: prof?.nickname ?: "ID ${prof?.id}", style = MaterialTheme.typography.headlineSmall)
+                    val joined = state.friendStatus == "friends"
+                    val btnText = if (joined) "Выйти" else "Вступить"
+                    TextButton(onClick = { if (joined) vm.leave() else vm.join() }) {
+                        Text(btnText)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/narxoz/social/ui/orgs/OrganizationDetailViewModel.kt
+++ b/app/src/main/java/com/narxoz/social/ui/orgs/OrganizationDetailViewModel.kt
@@ -1,0 +1,52 @@
+package com.narxoz.social.ui.orgs
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.narxoz.social.repository.ProfileRepository
+import com.narxoz.social.repository.FriendsRepository
+import com.narxoz.social.ui.profile.AnotherProfileState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class OrganizationDetailViewModel(
+    private val orgId: Int,
+    private val profileRepo: ProfileRepository = ProfileRepository(),
+    private val friendsRepo: FriendsRepository = FriendsRepository(),
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(AnotherProfileState(isLoading = true))
+    val state: StateFlow<AnotherProfileState> = _state.asStateFlow()
+
+    init { load() }
+
+    fun load() = viewModelScope.launch {
+        _state.value = AnotherProfileState(isLoading = true)
+        val profileRes = profileRepo.loadById(orgId)
+        val statusRes = friendsRepo.status(orgId)
+        _state.value = AnotherProfileState(
+            profile = profileRes.getOrNull(),
+            friendStatus = statusRes.getOrNull()?.status,
+            isLoading = false,
+            error = profileRes.exceptionOrNull()?.message ?: statusRes.exceptionOrNull()?.message
+        )
+    }
+
+    fun join() = viewModelScope.launch {
+        friendsRepo.send(orgId)
+        load()
+    }
+
+    fun leave() = viewModelScope.launch {
+        friendsRepo.remove(orgId)
+        load()
+    }
+}
+
+class OrganizationDetailVmFactory(private val orgId: Int) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T =
+        OrganizationDetailViewModel(orgId) as T
+}

--- a/app/src/main/java/com/narxoz/social/ui/orgs/OrganizationsScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/orgs/OrganizationsScreen.kt
@@ -61,7 +61,7 @@ fun OrganizationsScreen(
                         Modifier
                             .fillMaxWidth()
                             .padding(bottom = 8.dp)
-                            .clickable { navController.navigate("organization/${'$'}{org.id}") },
+                            .clickable { navController.navigate("organization/${org.id}") },
                         colors = CardDefaults.cardColors(
                             containerColor = MaterialTheme.colorScheme.surfaceContainerLow
                         )

--- a/app/src/main/java/com/narxoz/social/ui/orgs/OrganizationsScreen.kt
+++ b/app/src/main/java/com/narxoz/social/ui/orgs/OrganizationsScreen.kt
@@ -1,7 +1,9 @@
 package com.narxoz.social.ui.orgs
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -17,6 +19,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.narxoz.social.R
+import com.narxoz.social.ui.navigation.LocalNavController
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -24,6 +27,7 @@ fun OrganizationsScreen(
     vm: OrganizationsViewModel = viewModel()
 ) {
     val state by vm.state.collectAsState()
+    val navController = LocalNavController.current
 
     Scaffold(
         topBar = {
@@ -54,7 +58,10 @@ fun OrganizationsScreen(
             ) {
                 items(state.items) { org ->
                     Card(
-                        Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp)
+                            .clickable { navController.navigate("organization/${'$'}{org.id}") },
                         colors = CardDefaults.cardColors(
                             containerColor = MaterialTheme.colorScheme.surfaceContainerLow
                         )
@@ -63,19 +70,26 @@ fun OrganizationsScreen(
                             Modifier
                                 .fillMaxWidth()
                                 .padding(12.dp),
-                            verticalAlignment = Alignment.CenterVertically
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
                         ) {
-                            AsyncImage(
-                                model = org.avatarUrl ?: "",
-                                contentDescription = null,
-                                modifier = Modifier.size(48.dp),
-                                placeholder = painterResource(R.drawable.placeholder),
-                                error       = painterResource(R.drawable.placeholder)
-                            )
-                            Spacer(Modifier.width(12.dp))
-                            Column {
-                                Text(org.title,    style = MaterialTheme.typography.titleMedium)
-                                Text(org.subtitle, style = MaterialTheme.typography.bodySmall)
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                AsyncImage(
+                                    model = org.avatarUrl ?: "",
+                                    contentDescription = null,
+                                    modifier = Modifier.size(48.dp),
+                                    placeholder = painterResource(R.drawable.placeholder),
+                                    error       = painterResource(R.drawable.placeholder)
+                                )
+                                Spacer(Modifier.width(12.dp))
+                                Column {
+                                    Text(org.title,    style = MaterialTheme.typography.titleMedium)
+                                    Text(org.subtitle, style = MaterialTheme.typography.bodySmall)
+                                }
+                            }
+                            val btnText = if (org.joined) "Выйти" else "Вступить"
+                            TextButton(onClick = { if (org.joined) vm.leave(org.id) else vm.join(org.id) }) {
+                                Text(btnText)
                             }
                         }
                     }

--- a/app/src/main/java/com/narxoz/social/ui/orgs/OrganizationsViewModel.kt
+++ b/app/src/main/java/com/narxoz/social/ui/orgs/OrganizationsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.narxoz.social.api.dto.OrganizationDto
 import com.narxoz.social.repository.OrganizationsRepository
+import com.narxoz.social.repository.FriendsRepository
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
@@ -17,11 +18,13 @@ data class OrgUi(
     val id: Int,
     val title: String,
     val subtitle: String,
-    val avatarUrl: String?
+    val avatarUrl: String?,
+    val joined: Boolean = false,
 )
 
 class OrganizationsViewModel(
-    private val repo: OrganizationsRepository = OrganizationsRepository()
+    private val repo: OrganizationsRepository = OrganizationsRepository(),
+    private val friendsRepo: FriendsRepository = FriendsRepository(),
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(OrgsState(isLoading = true))
@@ -31,21 +34,34 @@ class OrganizationsViewModel(
 
     fun reload() = viewModelScope.launch {
         _state.value = OrgsState(isLoading = true)
-        repo.load()
-            .onSuccess { dtos ->
-                val mapped = dtos.map { dto ->
-                    OrgUi(
-                        id        = dto.id,
-                        title     = dto.fullName,
-                        subtitle  = "@${dto.nickname}",
-                        avatarUrl = dto.avatarPath
-                            ?.replace("127.0.0.1", "10.0.2.2")
-                    )
-                }
-                _state.value = OrgsState(items = mapped)
+        val orgsRes = repo.load()
+        val friendsRes = friendsRepo.list()
+
+        if (orgsRes.isSuccess) {
+            val friendIds = friendsRes.getOrElse { emptyList() }.map { it.id }
+            val mapped = orgsRes.getOrDefault(emptyList()).map { dto ->
+                OrgUi(
+                    id        = dto.id,
+                    title     = dto.fullName,
+                    subtitle  = "@${dto.nickname}",
+                    avatarUrl = dto.avatarPath
+                        ?.replace("127.0.0.1", "10.0.2.2"),
+                    joined    = friendIds.contains(dto.id),
+                )
             }
-            .onFailure { e ->
-                _state.value = OrgsState(error = e.message ?: "Ошибка загрузки")
-            }
+            _state.value = OrgsState(items = mapped)
+        } else {
+            _state.value = OrgsState(error = orgsRes.exceptionOrNull()?.message ?: "Ошибка загрузки")
+        }
+    }
+
+    fun join(id: Int) = viewModelScope.launch {
+        friendsRepo.send(id)
+        reload()
+    }
+
+    fun leave(id: Int) = viewModelScope.launch {
+        friendsRepo.remove(id)
+        reload()
     }
 }


### PR DESCRIPTION
## Summary
- show join/leave controls in organization list
- add organization detail screen
- allow editing own organization via existing profile editor
- wire new navigation destination

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce771ad00832581e24449ea7693a3